### PR TITLE
Allow immutable pixel reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Rust library for accessing geospatial raster images.
 Read height pixel value from GeoTIFF:
 ```rust
 let img_file = BufReader::new(File::open("N265E425.tif").unwrap());
-let mut tiff = GeoTiffReader::open(img_file).unwrap();
+let tiff = GeoTiffReader::open(img_file).unwrap();
 let height = tiff.read_pixel(x, y).height();
 ```
 

--- a/examples/pixel.rs
+++ b/examples/pixel.rs
@@ -16,7 +16,7 @@ fn main() {
         .expect("Y required");
 
     let img_file = BufReader::new(File::open(src_fn).expect("Open input file"));
-    let mut tiff = GeoTiffReader::open(img_file).expect("Open Tiff");
+    let tiff = GeoTiffReader::open(img_file).expect("Open Tiff");
     let pixel = tiff.read_pixel(x, y);
     println!("{pixel}");
 }

--- a/src/geotiff.rs
+++ b/src/geotiff.rs
@@ -157,7 +157,7 @@ impl<R: Read + Seek + Send> GeoTiffReader<R> {
     /// use georaster::geotiff::GeoTiffReader;
     ///
     /// let img_file = BufReader::new(File::open("data/tiff/utm.tif").unwrap());
-    /// let mut tiff = GeoTiffReader::open(img_file).unwrap();
+    /// let tiff = GeoTiffReader::open(img_file).unwrap();
     ///
     /// let value = tiff.read_pixel(0, 0);
     /// ```
@@ -186,7 +186,7 @@ impl<R: Read + Seek + Send> GeoTiffReader<R> {
     /// use georaster::{Coordinate, geotiff::GeoTiffReader};
     ///
     /// let img_file = BufReader::new(File::open("data/tiff/utm.tif").unwrap());
-    /// let mut tiff = GeoTiffReader::open(img_file).unwrap();
+    /// let tiff = GeoTiffReader::open(img_file).unwrap();
     ///
     /// let location = Coordinate { x: 0.0, y: 0.0 };
     /// let value = tiff.read_pixel_at_location(location);

--- a/src/geotiff.rs
+++ b/src/geotiff.rs
@@ -5,6 +5,7 @@
 // GDAL COG driver: https://gdal.org/drivers/raster/cog.html
 
 use crate::{GeorasterResult, RasterValue};
+use std::cell::RefCell;
 use std::io::{Read, Seek};
 use tiff::decoder::{ifd, Decoder, DecodingResult};
 use tiff::tags::{PhotometricInterpretation, PlanarConfiguration, Tag};
@@ -14,7 +15,7 @@ use crate::Coordinate;
 
 /// GeoTIFF file reader
 pub struct GeoTiffReader<R: Read + Seek> {
-    decoder: Decoder<R>,
+    decoder: RefCell<Decoder<R>>,
     band_idx: u8,
     images: Vec<ImageInfo>,
     /// Current image in Decoder
@@ -66,7 +67,7 @@ impl<R: Read + Seek + Send> GeoTiffReader<R> {
         let cur_image_idx = images.len() - 1;
 
         let reader = GeoTiffReader {
-            decoder,
+            decoder: RefCell::new(decoder),
             band_idx: 0,
             images,
             cur_image_idx,
@@ -92,7 +93,7 @@ impl<R: Read + Seek + Send> GeoTiffReader<R> {
 
     /// Load image info into reader
     pub fn seek_to_image(&mut self, index: usize) -> GeorasterResult<()> {
-        self.decoder.seek_to_image(index)?;
+        self.decoder.get_mut().seek_to_image(index)?;
         self.cur_image_idx = index;
         Ok(())
     }
@@ -120,26 +121,26 @@ impl<R: Read + Seek + Send> GeoTiffReader<R> {
     }
 
     /// Image dimensions or (0, 0) if undefined.
-    fn dimensions_or_zero(&mut self) -> (u32, u32) {
-        self.decoder.dimensions().unwrap_or((0, 0))
+    fn dimensions_or_zero(&self) -> (u32, u32) {
+        self.decoder.borrow_mut().dimensions().unwrap_or((0, 0))
     }
 
     /// Returns the default chunk size for the current image.
     fn chunk_dimensions(&self) -> (u32, u32) {
-        self.decoder.chunk_dimensions()
+        self.decoder.borrow().chunk_dimensions()
     }
 
     /// band count of current image.
-    fn num_bands(&mut self) -> u8 {
+    fn num_bands(&self) -> u8 {
         self.image_info().samples
     }
 
     /// Samples per pixel
-    fn spp(&mut self) -> u8 {
+    fn spp(&self) -> u8 {
         match self.image_info().planar_config {
             Some(PlanarConfiguration::Planar) => 1,
             _ => {
-                match self.decoder.colortype() {
+                match self.decoder.borrow_mut().colortype() {
                     Ok(tiff::ColorType::Gray(_)) => 1,
                     Ok(tiff::ColorType::RGB(_)) => 3,
                     Ok(tiff::ColorType::RGBA(_)) => 4,
@@ -160,7 +161,7 @@ impl<R: Read + Seek + Send> GeoTiffReader<R> {
     ///
     /// let value = tiff.read_pixel(0, 0);
     /// ```
-    pub fn read_pixel(&mut self, x: u32, y: u32) -> RasterValue {
+    pub fn read_pixel(&self, x: u32, y: u32) -> RasterValue {
         let image_dims = self.dimensions_or_zero();
         if x >= image_dims.0 || y >= image_dims.1 {
             return RasterValue::NoData;
@@ -171,7 +172,7 @@ impl<R: Read + Seek + Send> GeoTiffReader<R> {
         let chunk_index = tiles.get_chunk_index(x, y, self.band_idx);
         let spp = self.spp();
         let offset = tiles.get_chunk_offset(chunk_index, x, y, spp);
-        let chunk = self.decoder.read_chunk(chunk_index).unwrap();
+        let chunk = self.decoder.borrow_mut().read_chunk(chunk_index).unwrap();
         raster_value(&chunk, offset, spp)
     }
 
@@ -190,7 +191,7 @@ impl<R: Read + Seek + Send> GeoTiffReader<R> {
     /// let location = Coordinate { x: 0.0, y: 0.0 };
     /// let value = tiff.read_pixel_at_location(location);
     /// ```
-    pub fn read_pixel_at_location(&mut self, coord: impl Into<Coordinate>) -> RasterValue {
+    pub fn read_pixel_at_location(&self, coord: impl Into<Coordinate>) -> RasterValue {
         if let Some((x, y)) = self.coord_to_pixel(coord) {
             self.read_pixel(x, y)
         } else {
@@ -201,14 +202,14 @@ impl<R: Read + Seek + Send> GeoTiffReader<R> {
     /// Returns an Iterator over the pixels of an image part.
     /// The iterator yields the coordinates of each pixel
     /// along with their value
-    pub fn pixels(&mut self, x: u32, y: u32, width: u32, height: u32) -> Pixels<R> {
+    pub fn pixels(&mut self, x: u32, y: u32, width: u32, height: u32) -> Pixels<'_, R> {
         let image_dims = self.dimensions_or_zero();
-        let chunk_dims = self.decoder.chunk_dimensions();
+        let chunk_dims = self.decoder.borrow().chunk_dimensions();
         let dims =
             TileAttributes::from_dims(image_dims, chunk_dims, self.image_info().planar_config);
         let spp = self.spp();
         Pixels {
-            decoder: &mut self.decoder,
+            decoder: self.decoder.get_mut(),
             chunk: Err(TiffError::LimitsExceeded),
             offset: 0,
             x,

--- a/tests/geotiff.rs
+++ b/tests/geotiff.rs
@@ -58,7 +58,7 @@ fn single_band() {
 #[test]
 fn byte() {
     let img_file = BufReader::new(File::open("data/tiff/byte.tif").expect("Open image file"));
-    let mut tiff = GeoTiffReader::open(img_file).expect("Open Tiff");
+    let tiff = GeoTiffReader::open(img_file).expect("Open Tiff");
 
     let img = tiff.images().first().expect("Image info");
     assert_eq!(img.dimensions, Some((20, 20)));
@@ -77,7 +77,7 @@ fn byte() {
 #[test]
 fn float32() {
     let img_file = BufReader::new(File::open("data/tiff/float32.tif").expect("Open image file"));
-    let mut tiff = GeoTiffReader::open(img_file).expect("Open Tiff");
+    let tiff = GeoTiffReader::open(img_file).expect("Open Tiff");
 
     let img = tiff.images().first().expect("Image info");
     assert_eq!(img.dimensions, Some((20, 20)));
@@ -92,7 +92,7 @@ fn float32() {
 #[test]
 fn int16() {
     let img_file = BufReader::new(File::open("data/tiff/int16.tif").expect("Open image file"));
-    let mut tiff = GeoTiffReader::open(img_file).expect("Open Tiff");
+    let tiff = GeoTiffReader::open(img_file).expect("Open Tiff");
 
     let img = tiff.images().first().expect("Image info");
     assert_eq!(img.dimensions, Some((20, 20)));
@@ -108,7 +108,7 @@ fn int16() {
 #[test]
 fn int32() {
     let img_file = BufReader::new(File::open("data/tiff/int32.tif").expect("Open image file"));
-    let mut tiff = GeoTiffReader::open(img_file).expect("Open Tiff");
+    let tiff = GeoTiffReader::open(img_file).expect("Open Tiff");
 
     let img = tiff.images().first().expect("Image info");
     assert_eq!(img.dimensions, Some((20, 20)));
@@ -123,7 +123,7 @@ fn int32() {
 #[test]
 fn rgbsmall() {
     let img_file = BufReader::new(File::open("data/tiff/rgbsmall.tif").expect("Open image file"));
-    let mut tiff = GeoTiffReader::open(img_file).expect("Open Tiff");
+    let tiff = GeoTiffReader::open(img_file).expect("Open Tiff");
     let img = tiff.images().first().expect("Image info");
     assert_eq!(img.dimensions, Some((50, 50)));
     assert_eq!(img.colortype, Some(tiff::ColorType::RGB(8)));
@@ -311,7 +311,7 @@ fn small_world_pct() {
 #[test]
 fn utm() {
     let img_file = BufReader::new(File::open("data/tiff/utm.tif").expect("Open image file"));
-    let mut tiff = GeoTiffReader::open(img_file).expect("Open Tiff");
+    let tiff = GeoTiffReader::open(img_file).expect("Open Tiff");
     let img = tiff.images().first().expect("Image info");
     assert_eq!(img.dimensions, Some((512, 512)));
     assert_eq!(img.colortype, Some(tiff::ColorType::Gray(8)));
@@ -470,7 +470,7 @@ fn rgb() {
 fn rgb_bands() {
     let img_file =
         BufReader::new(File::open("data/tiff/sat_multiband.tif").expect("Open image file"));
-    let mut tiff = GeoTiffReader::open(img_file).expect("Open Tiff");
+    let tiff = GeoTiffReader::open(img_file).expect("Open Tiff");
     let img = tiff.images().first().expect("Image info");
     assert_eq!(img.dimensions, Some((200, 200)));
     assert_eq!(img.colortype, Some(tiff::ColorType::RGB(8)));
@@ -489,7 +489,7 @@ fn rgb_bands() {
 fn read_coord() {
     let img_file =
         BufReader::new(File::open("data/tiff/small_world.tif").expect("Open image file"));
-    let mut tiff = GeoTiffReader::open(img_file).expect("Open Tiff");
+    let tiff = GeoTiffReader::open(img_file).expect("Open Tiff");
 
     let location = Coordinate { x: -90.0, y: 45.0 };
     let (pixel_x, pixel_y) = tiff.coord_to_pixel(location).unwrap();

--- a/tests/geotiff.rs
+++ b/tests/geotiff.rs
@@ -502,6 +502,25 @@ fn read_coord() {
 }
 
 #[test]
+fn read_pixel_without_mutability() {
+    let img_file = BufReader::new(File::open("data/tiff/byte.tif").expect("Open image file"));
+    let tiff = GeoTiffReader::open(img_file).expect("Open Tiff");
+    let reader = &tiff;
+
+    let location = Coordinate {
+        x: 440720.0,
+        y: 3751320.0,
+    };
+
+    // convert -quiet data/tiff/byte.tif[0] -crop 1x1+0+0 txt:
+    assert_eq!(reader.read_pixel(0, 0), RasterValue::U8(107));
+    assert_eq!(
+        reader.read_pixel_at_location(location),
+        RasterValue::U8(107)
+    );
+}
+
+#[test]
 fn convert_pixel_coordinates() {
     let img_file =
         BufReader::new(File::open("data/tiff/small_world.tif").expect("Open image file"));

--- a/tests/geotiff.rs
+++ b/tests/geotiff.rs
@@ -502,25 +502,6 @@ fn read_coord() {
 }
 
 #[test]
-fn read_pixel_without_mutability() {
-    let img_file = BufReader::new(File::open("data/tiff/byte.tif").expect("Open image file"));
-    let tiff = GeoTiffReader::open(img_file).expect("Open Tiff");
-    let reader = &tiff;
-
-    let location = Coordinate {
-        x: 440720.0,
-        y: 3751320.0,
-    };
-
-    // convert -quiet data/tiff/byte.tif[0] -crop 1x1+0+0 txt:
-    assert_eq!(reader.read_pixel(0, 0), RasterValue::U8(107));
-    assert_eq!(
-        reader.read_pixel_at_location(location),
-        RasterValue::U8(107)
-    );
-}
-
-#[test]
 fn convert_pixel_coordinates() {
     let img_file =
         BufReader::new(File::open("data/tiff/small_world.tif").expect("Open image file"));


### PR DESCRIPTION
This change fixes #12.

`read_pixel` / `read_pixel_at_location` are read-style operations, but previously required `&mut self` because chunk reads mutate decoder internals.  
This PR updates API by using interior mutability for the decoder.

#### What changed
- `GeoTiffReader.decoder` now uses `RefCell<Decoder<R>>`.
- `read_pixel` and `read_pixel_at_location` now take `&self` (instead of `&mut self`).
- Small cleanup: explicit lifetime in `pixels` return type (`Pixels<'_, R>`) to remove the lifetime warning.

#### Compatibility
This should not break existing callers:
- Calls that currently pass `&mut self` still compile, because `&mut T` can be used where `&T` is expected.
